### PR TITLE
add:ログアウト機能

### DIFF
--- a/src/app/Http/Controllers/KnowledgeController.php
+++ b/src/app/Http/Controllers/KnowledgeController.php
@@ -2,12 +2,18 @@
 
 namespace App\Http\Controllers;
 
-use Illuminate\Http\Request;
-use App\Models\Uses;
+use Illuminate\Contracts\View\View;
 
 class KnowledgeController extends Controller
 {
-    public function index() {
+    /**
+     * 投稿一覧画面（top画面に遷移）
+     *
+     * @return View
+     */
+    public function index(): View
+    {
 
+        return view('top.index');
     }
 }

--- a/src/app/Http/Controllers/LoginController.php
+++ b/src/app/Http/Controllers/LoginController.php
@@ -84,10 +84,22 @@ class LoginController extends Controller
             return redirect()->route('Knowledge.index');
         }catch(Exception $e){
             logger($e);
-            
+
             DB::rollBack();
             return view('auth.register');
         }
+    }
+
+    /**
+     * ログアウト
+     *
+     * @return View
+     */
+    public function logout(): View
+    {
+        Auth::logout();
+
+        return view('auth.register');
     }
 }
 

--- a/src/resources/views/top/index.blade.php
+++ b/src/resources/views/top/index.blade.php
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+<head>
+    <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <title>Knowledge.top</title>
+        {{-- font --}}
+        <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700&display=swap" rel="stylesheet">
+
+</head>
+<body>
+    <a href="{{ route('Knowledge.logout')}}">ログアウト</a>
+</body>

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -24,6 +24,7 @@ Route::group(['prefix' => 'auth/{provider}', 'as' => 'sns' ], function () {
 
 Route::group(['prefix' => 'Knowledge', 'as' => 'Knowledge.', 'middleware' => 'auth'], function() {
     Route::get('', [App\Http\Controllers\KnowledgeController::class, 'index'])->name('index');
+    Route::get('logout', [App\Http\Controllers\LoginController::class, 'logout'])->name('logout');
 });
 
 


### PR DESCRIPTION
# 課題のリンク
・ログアウト

# 改修内容
・投稿一覧画面（top画面）にログアウトボタンを設置。
・ログアウトボタンを押下後、logoutメソッドでログアウト処理を行い、register.blade（ログイン画面)に遷移する。
（ログアウトボタンのレイアウト、デザインは後程行います。今は、ログアウト処理のみ改修しました。

# 検証内容
・Slack、Googleログインボタンを押した後、top画面に遷移し、ログインボタンが表示されたことを確認。
・ログアウトボタン押下後、logoutメソッドに遷移することをdd()で確認後、register.bladeに遷移することを確認。