### PR TITLE
add:新規投稿機能を追加

### DIFF
--- a/src/app/Http/Controllers/KnowledgeController.php
+++ b/src/app/Http/Controllers/KnowledgeController.php
@@ -2,10 +2,34 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\Posts;
+use App\Models\PostImages;
+use Exception;
 use Illuminate\Contracts\View\View;
+use App\Http\Requests\PostRequest;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Auth;
 
 class KnowledgeController extends Controller
 {
+    /**
+     * コンストラクタ(インスタンスの生成)
+     *
+     * @var Posts
+     * @var PostImages
+     */
+    private $posts;
+    private $postImages;
+    public function __construct(
+        Posts $posts,
+        PostImages $postImages
+    )
+    {
+        $this->posts = $posts;
+        $this->postImages = $postImages;
+    }
+
     /**
      * 投稿一覧画面（top画面に遷移）
      *
@@ -13,7 +37,54 @@ class KnowledgeController extends Controller
      */
     public function index(): View
     {
-
         return view('top.index');
+    }
+
+    /**
+     * 新規投稿画面に遷移
+     *
+     * @return View
+     */
+    public function create(): View
+    {
+        return view('Knowledge.post');
+    }
+
+    /**
+     * 新規投稿処理
+     *
+     * @param PostRequest $request
+     *
+     * @return　RedirectResponse
+     */
+    public function createPost(PostRequest $request): RedirectResponse
+    {
+        $userId = Auth::id();
+        $title = $request->input('title');
+        $content = $request->input('content');
+        $images = $request->file('images');
+
+        DB::beginTransaction();
+
+        try{
+            $postId = $this->posts->createPost($userId, $title, $content);
+
+            if(!is_null($images)){
+                foreach ($images as $image) {
+                    $imagePath = $image->store('public');
+                    $this->postImages->createImage($userId, $imagePath, $postId);
+                }
+            }
+
+            DB::commit();
+
+            return redirect()->route('Knowledge.index')->with('flash_message', '投稿が完了しました');
+        }catch(Exception $e){
+            logger($e);
+
+            DB::rollback();
+
+            return redirect()->route('Knowledge.index')->with('flash_message', '投稿に失敗しました');
+        }
     }
 }

--- a/src/app/Http/Controllers/LoginController.php
+++ b/src/app/Http/Controllers/LoginController.php
@@ -63,12 +63,12 @@ class LoginController extends Controller
      */
     public function handleProviderCallback(Request $request): RedirectResponse|view
     {
-        $provider = $request->provider;
-        $snsUser = Socialite::driver($provider)->user();
-
-        DB::beginTransaction();
-
         try{
+            $provider = $request->provider;
+            $snsUser = Socialite::driver($provider)->user();
+
+            DB::beginTransaction();
+
             $user = $this->users->createSnsUser($snsUser);
             auth()->login($user);
             $userId = Auth::id();

--- a/src/app/Http/Requests/PostRequest.php
+++ b/src/app/Http/Requests/PostRequest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use PhpParser\Node\NullableType;
+
+class PostRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * 新規投稿のバリデーション
+     */
+    public function rules()
+    {
+        return [
+            'title' =>['required', 'string', 'max:'. config('validation.title.MAX')],
+            'content' => ['required', 'string', 'max:'.config('validation.content.MAX')],
+            'images[]' => ['max:'. config('validation.images.MAX'), 'nullable' ],
+        ];
+    }
+
+    /**
+     * 新規投稿のエラーメッセージ
+     *
+     * @return array
+     */
+    public function messages()
+    {
+        return [
+            'title.required' => 'タイトルは必ず入力してください。',
+            'title.string' => 'タイトルは必ず文字列で入力してください',
+            'title.max' => 'タイトルは50文字以下にしてください',
+            'content.required' => '本文は必ず入力してください。',
+            'content.string' => '本文は必ず文字列で入力してください',
+            'content.max' => '本文は5000文字以下にして下さい',
+            'images[].max' => '画像は10GBにしてください',
+        ];
+    }
+}

--- a/src/app/Models/PostImages.php
+++ b/src/app/Models/PostImages.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class PostImages extends Model
+{
+    use HasFactory;
+
+    protected $table = 'post_images';
+    protected $fillable = ['post_id', 'user_id', 'fileName'];
+
+    /**
+     * 新規投稿処理
+     *
+     * @param  int $userId
+     * @param  string $imagePath
+     * @param int $postId
+     *
+     * @return Void
+     */
+    public function createImage($userId, $imagePath, $postId): Void
+    {
+        $postImage = new PostImages;
+        $postImage->post_id = $postId;
+        $postImage->user_id = $userId;
+        $postImage->img_path = $imagePath;
+
+        $postImage->save();
+    }
+}
+

--- a/src/app/Models/Posts.php
+++ b/src/app/Models/Posts.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Posts extends Model
+{
+    use HasFactory;
+
+    protected $table = 'posts';
+    protected $fillable = ['user_id', 'title', 'content'];
+
+    /**
+     * 投稿をpostテーブルに保存($post->idをreturnしたのは、画像保存処理に使うため)
+     *
+     * @param int $userId
+     * @param string $title
+     * @param string $content
+     *
+     * @return int
+     */
+    public function createPost($userId, $title, $content)
+    {
+        $posts = new Posts();
+        $posts->user_id = $userId;
+        $posts->title = $title;
+        $posts->content = $content;
+
+        $posts->save();
+
+        return $posts->id;
+    }
+
+
+
+}

--- a/src/config/validation.php
+++ b/src/config/validation.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'title' => [
+        'MAX' => 50,
+    ],
+    'content' => [
+        'MAX' => 5000,
+    ],
+    'images' => [
+        'MAX' => 10000,
+    ]
+];
+

--- a/src/database/migrations/2023_11_27_111527_create_posts_table.php
+++ b/src/database/migrations/2023_11_27_111527_create_posts_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('posts', function (Blueprint $table) {
+            $table->id();
+            $table->bigInteger('user_id');
+            $table->string('title');
+            $table->text('content');
+            $table->timestamp('created_at');
+            $table->timestamp('updated_at');
+            $table->timestamp('deleted_at')->nullable();
+        });
+    }
+    
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('posts');
+    }
+};

--- a/src/database/migrations/2023_11_28_021602_create_post_images_table.php
+++ b/src/database/migrations/2023_11_28_021602_create_post_images_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('post_images', function (Blueprint $table) {
+            $table->id();
+            $table->bigInteger('post_id');
+            $table->bigInteger('user_id');
+            $table->string('img_path');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('post_images');
+    }
+};

--- a/src/public/css/post.css
+++ b/src/public/css/post.css
@@ -1,0 +1,40 @@
+h1 {
+    text-align: center;
+    margin-top: 30px;
+}
+
+li {
+    display: flex;
+    justify-content: center;
+}
+form {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+label {
+    margin: 20px 0 5px 0;
+}
+
+.title {
+    width: 50vw;
+    height: 5vh;
+    border-radius: 3px;
+}
+
+textarea {
+    width: 50vw;
+    height:50vh;
+    border-radius: 3px;
+}
+
+.send-button {
+    width: 60px;
+    height: 30px;
+	border-radius: 0.3rem;
+    border: none;
+    background: #FFA07A;
+    cursor: pointer;
+    margin: 5px 0px 0px 600px;
+}

--- a/src/public/css/top.css
+++ b/src/public/css/top.css
@@ -1,0 +1,60 @@
+body{
+    height: 100vh;
+    width: 100vw;
+    display: flex;
+}
+
+.left-side-bar{
+    width: 10%;
+    height: 100vh;
+    background-color: #cdddbd;
+}
+
+.home-button {
+    width: 70px;
+    height: 60px;
+    margin: 250px 40px 0px;
+    border: none;
+    border-radius: 5px;
+    background-color: #ffffff;
+    cursor: pointer;
+}
+
+.trush-button {
+    width: 70px;
+    height: 60px;
+    margin: 50px 40px;
+    border: none;
+    border-radius: 5px;
+    background-color: #ffffff;
+    cursor: pointer;
+}
+.flex-column{
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    width: 100%;
+}
+
+header{
+    display: flex;
+    justify-content: flex-end;
+    height: 15%;
+    background-color: #cdddbd;
+}
+
+.post-button {
+    margin : 25px 60px 25px 30px;
+    width: 60px;
+    height: 50px;
+    border: none;
+    border-radius: 5px;
+    background-color: #ffffff;
+    cursor: pointer;
+}
+
+.user-name {
+    margin: auto 10px;
+    color: #000000;
+}
+

--- a/src/resources/views/auth/register.blade.php
+++ b/src/resources/views/auth/register.blade.php
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <title>User Register</title>
+        <title>認証画面</title>
         <link rel="stylesheet" href="{{ asset('/css/register.css') }}">
         {{-- font --}}
         <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700&display=swap" rel="stylesheet">

--- a/src/resources/views/knowledge/post.blade.php
+++ b/src/resources/views/knowledge/post.blade.php
@@ -1,0 +1,21 @@
+@extends('layout.master')
+@section('title', '新規投稿画面')
+
+<link rel="stylesheet" href="{{ asset('/css/post.css') }}">
+
+@section('content')
+    <h1>新規投稿機能</h1>
+    @foreach ($errors->all() as $error)
+        <li>{{$error}}</li>
+    @endforeach
+    <form action="{{ route('Knowledge.createPost')}}" method="post" enctype='multipart/form-data'>
+        @csrf
+        <label for="title">Title</label>
+        <input type="text" class="title" name="title">
+        <label for="posts">Content</label>
+        <textarea name="content"></textarea>
+        <input type="file" name="images[]" multiple/>
+        <button type="submit" class="send-button">送信</button>
+    </form>
+
+@endsection

--- a/src/resources/views/layout/master.blade.php
+++ b/src/resources/views/layout/master.blade.php
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+<head>
+    <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <title>@yield('title')</title>
+        {{-- font --}}
+        <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="{{ asset('/css/top.css') }}">
+</head>
+<body>
+    <aside class="left-side-bar">
+        <form method="GET" action="{{ route('Knowledge.index') }}" >
+            <button class="home-button">Home</button>
+        </form>
+        <button class="trush-button">g</button>
+    </aside>
+    <div class="flex-column">
+        <header>
+            <div class="user-name">
+                {{ Auth::user()->name}}
+            </div>
+            <form method="GET" action="{{ route('Knowledge.create') }}" >
+                <button class="post-button">投稿</button>
+            </form>
+        </header>
+        <main>
+            @yield('content')
+        </main>
+    </div>
+</body>

--- a/src/resources/views/top/index.blade.php
+++ b/src/resources/views/top/index.blade.php
@@ -1,13 +1,10 @@
-<!DOCTYPE html>
-<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
-<head>
-    <meta charset="utf-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1">
-        <title>Knowledge.top</title>
-        {{-- font --}}
-        <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700&display=swap" rel="stylesheet">
+@extends('layout.master')
+@section('title', 'top画面')
 
-</head>
-<body>
-    <a href="{{ route('Knowledge.logout')}}">ログアウト</a>
-</body>
+@section('content')
+@if (session('flash_message'))
+    <div class="flash_message">
+        {{ session('flash_message') }}
+    </div>
+@endif
+@endsection

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -23,8 +23,14 @@ Route::group(['prefix' => 'auth/{provider}', 'as' => 'sns' ], function () {
 });
 
 Route::group(['prefix' => 'Knowledge', 'as' => 'Knowledge.', 'middleware' => 'auth'], function() {
+    //投稿一覧画面表示（top画面）
     Route::get('', [App\Http\Controllers\KnowledgeController::class, 'index'])->name('index');
+    //ログアウト処理
     Route::get('logout', [App\Http\Controllers\LoginController::class, 'logout'])->name('logout');
+    // 新規投稿画面に遷移
+    Route::get('post', [App\Http\Controllers\KnowledgeController::class, 'create'])->name('create');
+    // 新規投稿処理を行い、投稿一覧画面に遷移する。
+    Route::post('', [App\Http\Controllers\KnowledgeController::class, 'createPost'])->name('createPost');
 });
 
 


### PR DESCRIPTION
# 課題のリンク
・新規投稿機能

# 改修内容
・ユーザー認証後、top画面（投稿一覧画面のheaderとleft-side-bar）のレイアウト作成
・投稿ボタン押下後、新規投稿画面に遷移。
・新規投稿画面のblade、レイアウト作成。
・投稿ボタン押下後、DB（postsテーブル、posts_imageテーブル)に投稿内容を保存
→top画面に遷移し、flashメッセージを表示
・バリデーションを設置し、バリデーションエラー時には、エラーメッセージを新規投稿画面に表示。

# 検証内容
・投稿ボタン押下後、DBに投稿内容の保存を確認。
・バリデーションエラー時にバリデーションメッセージの表示を確認。
・バリデーション通過後、投稿画面に遷移した後、flashメッセージの表示を確認。