### PR TITLE
add: 投稿詳細機能の追加

### DIFF
--- a/infra/nginx/default.conf
+++ b/infra/nginx/default.conf
@@ -1,4 +1,5 @@
 server {
+    client_max_body_size 20M;
     listen 443 ssl;
     server_name localhost;
     root /data/public;

--- a/src/app/Http/Controllers/KnowledgeController.php
+++ b/src/app/Http/Controllers/KnowledgeController.php
@@ -38,7 +38,7 @@ class KnowledgeController extends Controller
     public function index(): View
     {
         $posts = $this->posts->getAllPosts();
-        
+
         return view('top.index', compact('posts'));
     }
 
@@ -73,7 +73,7 @@ class KnowledgeController extends Controller
 
             if(!is_null($images)){
                 foreach ($images as $image) {
-                    $imagePath = $image->store('public');
+                    $imagePath = $image->store('public/avatar');
                     $this->postImages->createImage($userId, $imagePath, $postId);
                 }
             }
@@ -88,5 +88,13 @@ class KnowledgeController extends Controller
 
             return redirect()->route('Knowledge.index')->with('flash_message', '投稿に失敗しました');
         }
+    }
+
+    public function KnowledgeDetail(int $postId)
+    {
+        $posts = $this->posts->getPost($postId);
+        $postImages = $this->postImages->getPostImage($postId);
+
+        return view('post.detail', compact('posts', 'postImages'));
     }
 }

--- a/src/app/Http/Controllers/KnowledgeController.php
+++ b/src/app/Http/Controllers/KnowledgeController.php
@@ -71,12 +71,20 @@ class KnowledgeController extends Controller
         try{
             $postId = $this->posts->createPost($userId, $title, $content);
 
+            $postImage = [];
+
             if(!is_null($images)){
                 foreach ($images as $image) {
                     $imagePath = $image->store('public/avatar');
-                    $this->postImages->createImage($userId, $imagePath, $postId);
+                    $postImage = [
+                        'post_id' => $postId,
+                        'user_id' => $userId,
+                        'img_path' => $imagePath
+                    ];
                 }
             }
+            // それを一気にINSERTする。
+            $this->postImages->createImage($postImage);
 
             DB::commit();
 
@@ -90,7 +98,14 @@ class KnowledgeController extends Controller
         }
     }
 
-    public function KnowledgeDetail(int $postId)
+    /**
+     * 指定した投稿を取得
+     *
+     * @param integer $postId
+     *
+     * @return View
+     */
+    public function KnowledgeDetail(int $postId): View
     {
         $posts = $this->posts->getPost($postId);
         $postImages = $this->postImages->getPostImage($postId);

--- a/src/app/Models/PostImages.php
+++ b/src/app/Models/PostImages.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
@@ -29,6 +30,20 @@ class PostImages extends Model
         $postImage->img_path = $imagePath;
 
         $postImage->save();
+    }
+
+    /**
+     * 指定した投稿内の画像を取得する。
+     *
+     * @param int $postId
+     *
+     * @return Collection
+     */
+    public function getPostImage($postId): Collection
+    {
+        $postImage = PostImages::where('post_id', $postId)->get();
+
+        return $postImage;
     }
 }
 

--- a/src/app/Models/PostImages.php
+++ b/src/app/Models/PostImages.php
@@ -22,14 +22,9 @@ class PostImages extends Model
      *
      * @return Void
      */
-    public function createImage($userId, $imagePath, $postId): Void
+    public function createImage($postImage): Void
     {
-        $postImage = new PostImages;
-        $postImage->post_id = $postId;
-        $postImage->user_id = $userId;
-        $postImage->img_path = $imagePath;
-
-        $postImage->save();
+        PostImages::insert($postImage);
     }
 
     /**
@@ -41,9 +36,7 @@ class PostImages extends Model
      */
     public function getPostImage($postId): Collection
     {
-        $postImage = PostImages::where('post_id', $postId)->get();
-
-        return $postImage;
+        return  PostImages::where('post_id', $postId)->get();
     }
 }
 

--- a/src/app/Models/Posts.php
+++ b/src/app/Models/Posts.php
@@ -66,10 +66,8 @@ class Posts extends Model
      */
     public function getPost(int $postId): Collection
     {
-        $posts = Posts::where('id', $postId)
+        return Posts::where('id', $postId)
                 ->with(['users'])
                 ->get();
-
-        return $posts;
     }
 }

--- a/src/app/Models/Posts.php
+++ b/src/app/Models/Posts.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasOne;
@@ -44,9 +45,30 @@ class Posts extends Model
         return $posts->id;
     }
 
-    public function getAllPosts()
+    /**
+     * 全ての投稿を取得する
+     *
+     * @return Collection
+     */
+    public function getAllPosts(): Collection
     {
         $posts = Posts::with('users')->get();
+
+        return $posts;
+    }
+
+    /**
+     * ユーザーが指定した投稿を取得
+     *
+     * @param integer $postId
+     *
+     * @return Collection
+     */
+    public function getPost(int $postId): Collection
+    {
+        $posts = Posts::where('id', $postId)
+                ->with(['users'])
+                ->get();
 
         return $posts;
     }

--- a/src/public/css/index.css
+++ b/src/public/css/index.css
@@ -3,6 +3,11 @@ h1{
     justify-content: center;
 }
 
+a {
+    text-decoration: none;
+    color: inherit;
+}
+
 .card {
     background-color: #eeeeee;
     margin: 2% 0% 0% 20%;

--- a/src/public/css/index.css
+++ b/src/public/css/index.css
@@ -8,6 +8,11 @@ a {
     color: inherit;
 }
 
+.flash-message {
+    display: flex;
+    justify-content: center;
+}
+
 .card {
     background-color: #eeeeee;
     margin: 2% 0% 0% 20%;

--- a/src/public/css/post-detail.css
+++ b/src/public/css/post-detail.css
@@ -17,10 +17,10 @@ h3 {
 
 .content {
     margin: 2% 0 0 15%;
-    line-height: 170%;
+    line-height: 1.7;
 }
 
-.image {
+.post-image {
     margin: 2% 0 0 15%;
 }
 

--- a/src/public/css/post-detail.css
+++ b/src/public/css/post-detail.css
@@ -7,19 +7,24 @@ h1 {
     margin: 1% 0 0 15%;
 }
 
+p {
+    font-weight: bold;
+}
+
 h3 {
     margin: 1% 0 0 15%;
 }
 
 .content {
-    flex-wrap: wrap;
     margin: 2% 0 0 15%;
+    line-height: 170%;
 }
 
 .image {
     margin: 2% 0 0 15%;
 }
+
 img {
-    width:30%;
-    height:40%;
+    width:50%;
+    height:60%;
 }

--- a/src/public/css/post-detail.css
+++ b/src/public/css/post-detail.css
@@ -1,0 +1,25 @@
+h1 {
+    display: flex;
+    justify-content: center;
+}
+
+.post-details {
+    margin: 1% 0 0 15%;
+}
+
+h3 {
+    margin: 1% 0 0 15%;
+}
+
+.content {
+    flex-wrap: wrap;
+    margin: 2% 0 0 15%;
+}
+
+.image {
+    margin: 2% 0 0 15%;
+}
+img {
+    width:30%;
+    height:40%;
+}

--- a/src/resources/views/post/detail.blade.php
+++ b/src/resources/views/post/detail.blade.php
@@ -5,22 +5,23 @@
 
 @section('content')
 @auth
-@foreach($posts as $post)
-<h1>{{ $post->title }}</h1>
-<div class="post-details">
-    <p>{{ $post->users->name }}</p>
-    <p>{{ $post->updated_at->format('Y-m-d') }}</p>
-</div>
-<h3>Content</h3>
+@foreach ($posts as $post)
+    <h1>{{ $post->title }}</h1>
+    <div class="post-details">
+        <p>{{ $post->users->name }}</p>
+        <p>{{ $post->updated_at->format('Y-m-d') }}</p>
+    </div>
+    <h3>Content</h3>
     <div class="content">
         {{ $post->content }}
     </div>
+
+    @foreach ($postImages as $postImage)
+        <div class="post-image">
+            <p>[参考画像]</p>
+            <img src="{{ Storage::url($postImage->img_path) }}" />
+        </div>
     @endforeach
-    @foreach($postImages as $postImage)
-    <div class="image">
-        <p>[参考画像]</p>
-        <img src="{{ Storage::url($postImage->img_path) }}" />
-    </div>
 @endforeach
 @endauth
 @endsection

--- a/src/resources/views/post/detail.blade.php
+++ b/src/resources/views/post/detail.blade.php
@@ -9,7 +9,7 @@
 <h1>{{ $post->title }}</h1>
 <div class="post-details">
     <p>{{ $post->users->name }}</p>
-    <p>{{ $post->updated_at }}</p>
+    <p>{{ $post->updated_at->format('Y-m-d') }}</p>
 </div>
 <h3>Content</h3>
     <div class="content">

--- a/src/resources/views/post/detail.blade.php
+++ b/src/resources/views/post/detail.blade.php
@@ -1,0 +1,26 @@
+@extends('layout.master')
+@section('title', 'top画面')
+
+<link rel="stylesheet" href="{{ asset('/css/post-detail.css') }}">
+
+@section('content')
+@auth
+@foreach($posts as $post)
+<h1>{{ $post->title }}</h1>
+<div class="post-details">
+    <p>{{ $post->users->name }}</p>
+    <p>{{ $post->updated_at }}</p>
+</div>
+<h3>Content</h3>
+    <div class="content">
+        {{ $post->content }}
+    </div>
+    @endforeach
+    @foreach($postImages as $postImage)
+    <div class="image">
+        <p>[参考画像]</p>
+        <img src="{{ Storage::url($postImage->img_path) }}" />
+    </div>
+@endforeach
+@endauth
+@endsection

--- a/src/resources/views/top/index.blade.php
+++ b/src/resources/views/top/index.blade.php
@@ -12,17 +12,19 @@
 @endif
 <h1>投稿一覧</h1>
 @foreach($posts as $post)
-<div class="card">
-    <div class="post-name">
-        {{ $post->users->name }}
-    </div>
-    <div class="post-time">
-        {{ $post->updated_at}}
-    </div>
-    <div class="post-title">
-        {{ $post->title }}
-    </div>
-</div>
+    <a href="{{ route('Knowledge.detail', ['id' => $post->id]) }}" class="">
+        <div class="card">
+            <div class="post-name">
+                {{ $post->users->name }}
+            </div>
+            <div class="post-time">
+                {{ $post->updated_at}}
+            </div>
+            <div class="post-title">
+                {{ $post->title }}
+            </div>
+        </div>
+    </a>
 @endforeach
 @endauth
 @endsection

--- a/src/resources/views/top/index.blade.php
+++ b/src/resources/views/top/index.blade.php
@@ -7,7 +7,7 @@
 @auth
 @if (session('flash_message'))
     <div class="flash_message">
-        {{ session('flash_message') }}
+        {{ session('flash-message') }}
     </div>
 @endif
 <h1>投稿一覧</h1>

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -31,6 +31,8 @@ Route::group(['prefix' => 'Knowledge', 'as' => 'Knowledge.', 'middleware' => 'au
     Route::get('post', [App\Http\Controllers\KnowledgeController::class, 'create'])->name('create');
     // 新規投稿処理を行い、投稿一覧画面に遷移する。
     Route::post('', [App\Http\Controllers\KnowledgeController::class, 'createPost'])->name('createPost');
+    //投稿詳細画面に遷移
+    Route::get('{id}', [App\Http\Controllers\KnowledgeController::class, 'KnowledgeDetail'])->name('detail');
 });
 
 


### PR DESCRIPTION
# 課題のリンク
・投稿詳細機能

# 改修内容
・詳細を見たい投稿を押下できるよう、<a>タグを追加し、押下後、投稿詳細画面に遷移
・投稿詳細画面のblade作成(title、著者、作成時間、Content、投稿画像）

# 検証内容
・dd()を使い、詳細を見たい投稿がbladeに渡っているのかを確認。