### PR TITLE
add:投稿編集機能の追加

### DIFF
--- a/src/app/Http/Controllers/KnowledgeController.php
+++ b/src/app/Http/Controllers/KnowledgeController.php
@@ -4,12 +4,15 @@ namespace App\Http\Controllers;
 
 use App\Models\Posts;
 use App\Models\PostImages;
+use App\Http\Requests\PostRequest;
 use Exception;
 use Illuminate\Contracts\View\View;
-use App\Http\Requests\PostRequest;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Storage;
+use Ramsey\Uuid\Type\Integer;
 
 class KnowledgeController extends Controller
 {
@@ -57,7 +60,7 @@ class KnowledgeController extends Controller
      *
      * @param PostRequest $request
      *
-     * @return　RedirectResponse
+     * @return RedirectResponse
      */
     public function createPost(PostRequest $request): RedirectResponse
     {
@@ -83,7 +86,6 @@ class KnowledgeController extends Controller
                     ];
                 }
             }
-            // それを一気にINSERTする。
             $this->postImages->createImage($postImage);
 
             DB::commit();
@@ -101,15 +103,91 @@ class KnowledgeController extends Controller
     /**
      * 指定した投稿を取得
      *
-     * @param integer $postId
+     * @param int $postId
      *
      * @return View
      */
-    public function KnowledgeDetail(int $postId): View
+    public function KnowledgeDetail($postId): View
     {
         $posts = $this->posts->getPost($postId);
         $postImages = $this->postImages->getPostImage($postId);
 
         return view('post.detail', compact('posts', 'postImages'));
+    }
+
+    /**
+     * 編集画面に遷移
+     *
+     * @param integer $postId
+     *
+     * @return View
+     */
+    public function showEdit(int $postId): View
+    {
+        $posts = $this->posts->getPost($postId);
+        $postImages = $this->postImages->getPostImage($postId);
+
+        return view('post.edit', compact('posts', 'postImages'));
+    }
+
+    /**
+     * 認可
+     *
+     * @param int $postId
+     * 
+     * @return bool
+     */
+    public function isAuthenticatedUserPost(int $postId): bool
+    {
+        return $this->posts->getPostId($postId) === Auth::id();
+    }
+
+
+    /**
+     * 投稿編集処理
+     *
+     * @param PostRequest $request
+     * @param int $postId
+     *
+     * @return RedirectResponse
+     */
+    public function updatePost(PostRequest $request, int $postId): RedirectResponse
+    {
+        $userId = Auth::id();
+        $title = $request->input('title');
+        $content = $request->input('content');
+        $images = $request->file('images');
+
+        $flashMessage = "投稿編集に成功しました";
+
+        DB::beginTransaction();
+
+        try{
+            if($this->isAuthenticatedUserPost($postId)){
+                $this->posts->updatePost($postId, $title, $content);
+                $postedImages = $this->postImages->getPostImage($postId);
+
+                foreach ($postedImages as $postedImage) {
+                    Storage::delete($postedImage->img_path);
+                }
+
+                if (!is_null($images)) {
+                    foreach ($images as $image) {
+                        $imagePath = $image->store('public/avatar');
+                    }
+                $this->postImages->updateImage($userId, $postId, $imagePath);
+                }
+            }
+
+            DB::commit();
+
+            return redirect()->route('Knowledge.detail', ['id' => $postId])->with('flashMessage', $flashMessage);
+        }catch(Exception $e){
+            Logger($e);
+
+            DB:: rollBack();
+
+            return redirect()->route('Knowledge.detail', ['id' => $postId])->with('flashMessage', '投稿中にエラーが発生しました。');
+        }
     }
 }

--- a/src/app/Http/Controllers/KnowledgeController.php
+++ b/src/app/Http/Controllers/KnowledgeController.php
@@ -107,7 +107,7 @@ class KnowledgeController extends Controller
      *
      * @return View
      */
-    public function KnowledgeDetail($postId): View
+    public function KnowledgeDetail(int $postId): View
     {
         $posts = $this->posts->getPost($postId);
         $postImages = $this->postImages->getPostImage($postId);
@@ -134,7 +134,7 @@ class KnowledgeController extends Controller
      * 認可
      *
      * @param int $postId
-     * 
+     *
      * @return bool
      */
     public function isAuthenticatedUserPost(int $postId): bool

--- a/src/app/Models/PostImages.php
+++ b/src/app/Models/PostImages.php
@@ -16,13 +16,11 @@ class PostImages extends Model
     /**
      * 新規投稿処理
      *
-     * @param  int $userId
-     * @param  string $imagePath
-     * @param int $postId
+     * @param array $postImage
      *
      * @return Void
      */
-    public function createImage($postImage): Void
+    public function createImage(array $postImage): Void
     {
         PostImages::insert($postImage);
     }
@@ -34,9 +32,28 @@ class PostImages extends Model
      *
      * @return Collection
      */
-    public function getPostImage($postId): Collection
+    public function getPostImage(int $postId): Collection
     {
         return  PostImages::where('post_id', $postId)->get();
+    }
+
+    /**
+     * もし画像が既に投稿されていなかったら、DBにINSERTする。入っていたら、updateする。
+     *
+     * @param int $userId
+     * @param int $postId
+     * @param string  $imagePath
+     * @return void
+     */
+    public function updateImage(int $userId, int $postId, string $imagePath)
+    {
+        $postImages = PostImages::where('post_id', $postId)->get();
+
+        if($postImages->isEmpty())
+        {
+            PostImages::insert(['user_id' => $userId, 'post_id' => $postId, 'img_path' => $imagePath]);
+        }
+        PostImages::where('post_id', $postId)->update(['img_path' => $imagePath]);
     }
 }
 

--- a/src/app/Models/Posts.php
+++ b/src/app/Models/Posts.php
@@ -70,4 +70,30 @@ class Posts extends Model
                 ->with(['users'])
                 ->get();
     }
+
+    /**
+     * Pathパラメーターと一致したレコードを更新する。
+     *
+     * @param int $postId
+     * @param string $title
+     * @param string $content
+     *
+     * @return void
+     */
+    public function updatePost(int $postId, string $title, string $content): void
+    {
+        Posts::find($postId)->update(['title' => $title, 'content' => $content]);
+    }
+
+    /**
+     * Pathパラメーターに一致したレコードの、ユーザーIDを取得する
+     *
+     * @param int $postId
+     *
+     * @return int
+     */
+    public function getPostId(int $postId): int
+    {
+        return Posts::find($postId)->user_id;
+    }
 }

--- a/src/public/css/post-detail.css
+++ b/src/public/css/post-detail.css
@@ -3,8 +3,27 @@ h1 {
     justify-content: center;
 }
 
+.flash_message {
+    display: flex;
+    justify-content: center;
+}
+
 .post-details {
     margin: 1% 0 0 15%;
+}
+
+.edit-button {
+    margin: 0 0 0 60%;
+    border-radius: 10%;
+    border: none;
+    background-color: #f4f5f7;
+    width: 5%;
+    height: 4%;
+    cursor: pointer;
+}
+
+.edit-button:hover {
+    background-color: #ffffff;
 }
 
 p {

--- a/src/resources/views/post/detail.blade.php
+++ b/src/resources/views/post/detail.blade.php
@@ -7,10 +7,19 @@
 @auth
 @foreach ($posts as $post)
     <h1>{{ $post->title }}</h1>
+@if (session('flashMessage'))
+    <div class="flash_message">
+        {{ session('flashMessage') }}
+    </div>
+@endif
+
     <div class="post-details">
         <p>{{ $post->users->name }}</p>
         <p>{{ $post->updated_at->format('Y-m-d') }}</p>
     </div>
+    <form action="{{ route('Knowledge.edit', ['id' => $post->id ])}}" method="get">
+        <button class="edit-button">編集</button>
+    </form>
     <h3>Content</h3>
     <div class="content">
         {{ $post->content }}

--- a/src/resources/views/post/edit.blade.php
+++ b/src/resources/views/post/edit.blade.php
@@ -1,0 +1,25 @@
+@extends('layout.master')
+@section('title', '投稿編集画面')
+
+<link rel="stylesheet" href="{{ asset('/css/post.css') }}">
+
+@section('content')
+@auth
+<h1>投稿編集</h1>
+@foreach ($errors->all() as $error)
+    <li>{{$error}}</li>
+@endforeach
+    @foreach($posts as $post)
+        <form action="{{ route('Knowledge.update', ['id' => $post->id ])}}" method="post" enctype='multipart/form-data'>
+            @csrf
+            @method('put')
+            <label for="title">Title</label>
+            <input type="text" class="title" name="title" value={{ $post->title }}>
+            <label for="posts">Content</label>
+            <textarea name="content">{{ $post->content }}</textarea>
+            <input type="file" name="images[]" multiple/>
+            <button type="submit" class="send-button">送信</button>
+        </form>
+    @endforeach
+@endauth
+@endsection

--- a/src/resources/views/top/index.blade.php
+++ b/src/resources/views/top/index.blade.php
@@ -7,18 +7,18 @@
 @auth
 @if (session('flash_message'))
     <div class="flash_message">
-        {{ session('flash-message') }}
+        {{ session('flash_message') }}
     </div>
 @endif
 <h1>投稿一覧</h1>
 @foreach($posts as $post)
-    <a href="{{ route('Knowledge.detail', ['id' => $post->id]) }}" class="">
+    <a href="{{ route('Knowledge.detail', ['id' => $post->id]) }}">
         <div class="card">
             <div class="post-name">
                 {{ $post->users->name }}
             </div>
             <div class="post-time">
-                {{ $post->updated_at}}
+                {{ $post->updated_at->format('Y-m-d')}}
             </div>
             <div class="post-title">
                 {{ $post->title }}

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -31,9 +31,14 @@ Route::group(['prefix' => 'Knowledge', 'as' => 'Knowledge.', 'middleware' => 'au
     Route::get('post', [App\Http\Controllers\KnowledgeController::class, 'create'])->name('create');
     // 新規投稿処理を行い、投稿一覧画面に遷移する。
     Route::post('', [App\Http\Controllers\KnowledgeController::class, 'createPost'])->name('createPost');
+    // 投稿編集画面に遷移
+    Route::get('{id}/edit', [App\Http\Controllers\KnowledgeController::class, 'showEdit'])->name('edit');
     //投稿詳細画面に遷移
     Route::get('{id}', [App\Http\Controllers\KnowledgeController::class, 'KnowledgeDetail'])->name('detail');
+    //投稿編集処理をし、投稿詳細画面に遷移
+    Route::put('{id}', [App\Http\Controllers\KnowledgeController::class, 'updatePost'])->name('update');
 });
+
 
 
 


### PR DESCRIPTION
# 課題のリンク
・投稿編集機能

# 改修内容
・投稿詳細画面に、編集ボタンを作成
・編集ボタンを押下後、
１、投稿内容をupdate。
２、'public'配下にある既に投稿したファイルを削除。
３、新しい画像のPathはDB内でupdate、画像は'public'配下にINSERTした。

・編集処理完了後、投稿詳細画面に遷移し、flashMessageを表示。
・バリデーション（PostRequest）を設置。

# 検証内容
・dd()を使い、投稿内容（title, content)がController、PostModelに渡っていることを確認
・Postテーブルにて、投稿内容がupdateされていることを確認。
・画像が削除され、新たな画像、Pathが挿入されていることを確認
・バリデーションが設置できており、バリデーションメッセージが表示されていることを確認。
・編集処理完了後、投稿詳細画面に遷移し、flashメッセージが表示されていることを確認。