### PR TITLE
add: 投稿削除機能の追加

### DIFF
--- a/src/app/Http/Controllers/KnowledgeController.php
+++ b/src/app/Http/Controllers/KnowledgeController.php
@@ -134,7 +134,7 @@ class KnowledgeController extends Controller
      * 認可
      *
      * @param int $postId
-     * 
+     *
      * @return bool
      */
     public function isAuthenticatedUserPost(int $postId): bool
@@ -185,9 +185,42 @@ class KnowledgeController extends Controller
         }catch(Exception $e){
             Logger($e);
 
-            DB:: rollBack();
+            DB::rollBack();
 
             return redirect()->route('Knowledge.detail', ['id' => $postId])->with('flashMessage', '投稿中にエラーが発生しました。');
         }
+    }
+
+    /**
+     * 投稿削除処理
+     *
+     * @param int $postId
+     *
+     * @return RedirectResponse
+     */
+    public function deletePost(int $postId): RedirectResponse
+    {
+        $flashMessage="投稿削除に失敗しました。";
+
+        try{
+            if($this->isAuthenticatedUserPost($postId)){
+            $this->posts->deletePost($postId);
+            $postedImages = $this->postImages->getPostImage($postId);
+
+            foreach ($postedImages as $postedImage) {
+                Storage::delete($postedImage->img_path);
+                $this->postImages->deletePostImage($postId);
+            }
+
+            $flashMessage = "投稿削除に成功しました";
+            }
+
+            return redirect()->route('Knowledge.index')->with('flash_message', $flashMessage);
+        }catch(Exception $e){
+            Logger($e);
+
+            return redirect()->route('Knowledge.index')->with('flashMessage', '削除中にエラーが発生しました。');
+        }
+
     }
 }

--- a/src/app/Http/Controllers/KnowledgeController.php
+++ b/src/app/Http/Controllers/KnowledgeController.php
@@ -107,7 +107,7 @@ class KnowledgeController extends Controller
      *
      * @return View
      */
-    public function KnowledgeDetail($postId): View
+    public function KnowledgeDetail(int $postId): View
     {
         $posts = $this->posts->getPost($postId);
         $postImages = $this->postImages->getPostImage($postId);
@@ -134,7 +134,7 @@ class KnowledgeController extends Controller
      * 認可
      *
      * @param int $postId
-     * 
+     *
      * @return bool
      */
     public function isAuthenticatedUserPost(int $postId): bool

--- a/src/app/Http/Controllers/KnowledgeController.php
+++ b/src/app/Http/Controllers/KnowledgeController.php
@@ -107,7 +107,7 @@ class KnowledgeController extends Controller
      *
      * @return View
      */
-    public function KnowledgeDetail($postId): View
+    public function KnowledgeDetail(int $postId): View
     {
         $posts = $this->posts->getPost($postId);
         $postImages = $this->postImages->getPostImage($postId);

--- a/src/app/Http/Controllers/KnowledgeController.php
+++ b/src/app/Http/Controllers/KnowledgeController.php
@@ -74,13 +74,13 @@ class KnowledgeController extends Controller
         try{
             $postId = $this->posts->createPost($userId, $title, $content);
 
-            if(!is_null($image)){
-                    $imagePath = $image->store('public/avatar');
-                    $postImage = [
-                        'post_id' => $postId,
-                        'user_id' => $userId,
-                        'img_path' => $imagePath
-                    ];
+            if(isset($image)){
+                $imagePath = $image->store('public/avatar');
+                $postImage = [
+                    'post_id' => $postId,
+                    'user_id' => $userId,
+                    'img_path' => $imagePath
+                ];
             }
             $this->postImages->createImage($postImage);
 
@@ -166,7 +166,7 @@ class KnowledgeController extends Controller
                     Storage::delete($postedImage->img_path);
                 }
 
-                if (!is_null($image)) {
+                if (isset($image)) {
                     $imagePath = $image->store('public/avatar');
                 }
                 $this->postImages->updateImage($userId, $postId, $imagePath);

--- a/src/app/Http/Controllers/KnowledgeController.php
+++ b/src/app/Http/Controllers/KnowledgeController.php
@@ -202,23 +202,28 @@ class KnowledgeController extends Controller
     {
         $flashMessage="投稿削除に失敗しました。";
 
+        DB::beginTransaction();
+        
         try{
             if($this->isAuthenticatedUserPost($postId)){
-            $this->posts->deletePost($postId);
-            $postedImages = $this->postImages->getPostImage($postId);
+                $this->posts->deletePost($postId);
+                $postedImages = $this->postImages->getPostImage($postId);
 
-            foreach ($postedImages as $postedImage) {
-                Storage::delete($postedImage->img_path);
                 $this->postImages->deletePostImage($postId);
-            }
 
-            $flashMessage = "投稿削除に成功しました";
+                foreach ($postedImages as $postedImage) {
+                    Storage::delete($postedImage->img_path);
+                }
+
+                $flashMessage = "投稿削除に成功しました";
             }
+            DB::commit();
 
             return redirect()->route('Knowledge.index')->with('flash_message', $flashMessage);
         }catch(Exception $e){
             Logger($e);
 
+            DB::rollBack();
             return redirect()->route('Knowledge.index')->with('flashMessage', '削除中にエラーが発生しました。');
         }
 

--- a/src/app/Http/Controllers/KnowledgeController.php
+++ b/src/app/Http/Controllers/KnowledgeController.php
@@ -67,24 +67,20 @@ class KnowledgeController extends Controller
         $userId = Auth::id();
         $title = $request->input('title');
         $content = $request->input('content');
-        $images = $request->file('images');
+        $image = $request->file('image');
 
         DB::beginTransaction();
 
         try{
             $postId = $this->posts->createPost($userId, $title, $content);
 
-            $postImage = [];
-
-            if(!is_null($images)){
-                foreach ($images as $image) {
+            if(!is_null($image)){
                     $imagePath = $image->store('public/avatar');
                     $postImage = [
                         'post_id' => $postId,
                         'user_id' => $userId,
                         'img_path' => $imagePath
                     ];
-                }
             }
             $this->postImages->createImage($postImage);
 
@@ -125,9 +121,8 @@ class KnowledgeController extends Controller
     public function showEdit(int $postId): View
     {
         $posts = $this->posts->getPost($postId);
-        $postImages = $this->postImages->getPostImage($postId);
 
-        return view('post.edit', compact('posts', 'postImages'));
+        return view('post.edit', compact('posts'));
     }
 
     /**
@@ -156,7 +151,7 @@ class KnowledgeController extends Controller
         $userId = Auth::id();
         $title = $request->input('title');
         $content = $request->input('content');
-        $images = $request->file('images');
+        $image = $request->file('image');
 
         $flashMessage = "投稿編集に成功しました";
 
@@ -171,12 +166,10 @@ class KnowledgeController extends Controller
                     Storage::delete($postedImage->img_path);
                 }
 
-                if (!is_null($images)) {
-                    foreach ($images as $image) {
-                        $imagePath = $image->store('public/avatar');
-                    }
-                $this->postImages->updateImage($userId, $postId, $imagePath);
+                if (!is_null($image)) {
+                    $imagePath = $image->store('public/avatar');
                 }
+                $this->postImages->updateImage($userId, $postId, $imagePath);
             }
 
             DB::commit();
@@ -203,7 +196,7 @@ class KnowledgeController extends Controller
         $flashMessage="投稿削除に失敗しました。";
 
         DB::beginTransaction();
-        
+
         try{
             if($this->isAuthenticatedUserPost($postId)){
                 $this->posts->deletePost($postId);

--- a/src/app/Models/PostImages.php
+++ b/src/app/Models/PostImages.php
@@ -55,5 +55,17 @@ class PostImages extends Model
         }
         PostImages::where('post_id', $postId)->update(['img_path' => $imagePath]);
     }
+
+    /**
+     * $postIdと一致した投稿の画像を削除する。
+     *
+     * @param int $postId
+     *
+     * @return void
+     */
+    public function deletePostImage(int $postId)
+    {
+        PostImages::where('post_id', $postId)->delete();
+    }
 }
 

--- a/src/app/Models/Posts.php
+++ b/src/app/Models/Posts.php
@@ -96,4 +96,16 @@ class Posts extends Model
     {
         return Posts::find($postId)->user_id;
     }
+
+    /**
+     * $postIdと一致した投稿を削除する
+     *
+     * @param int $postId
+     *
+     * @return void
+     */
+    public function deletePost(int $postId): void
+    {
+        Posts::find($postId)->delete();
+    }
 }

--- a/src/public/css/index.css
+++ b/src/public/css/index.css
@@ -8,7 +8,7 @@ a {
     color: inherit;
 }
 
-.flash-message {
+.flash_message {
     display: flex;
     justify-content: center;
 }

--- a/src/public/css/post-detail.css
+++ b/src/public/css/post-detail.css
@@ -1,6 +1,5 @@
 h1 {
-    display: flex;
-    justify-content: center;
+    text-align: center;
 }
 
 .flash_message {
@@ -28,7 +27,7 @@ h1 {
 .edit-button {
     border-radius: 10%;
     border: none;
-    background-color: #007bff;
+    background-color: #95CCFF;
     width: 50px;
     height: 40px;
     margin-right: 10px;
@@ -38,7 +37,7 @@ h1 {
 .delete-button {
     border-radius: 10%;
     border: none;
-    background-color: #dc3545;
+    background-color: #f26651;
     width: 50px;
     height: 40px;
 

--- a/src/public/css/post-detail.css
+++ b/src/public/css/post-detail.css
@@ -8,30 +8,53 @@ h1 {
     justify-content: center;
 }
 
+.post-container {
+    display: flex;
+    justify-content: space-between;
+}
+
 .post-details {
-    margin: 1% 0 0 15%;
+    display: flex;
+    flex-direction: column;
+    margin-left: 15%;
+}
+
+.post-actions {
+    display: flex;
+    flex-direction: row;
+    margin: 5% 30% 0 0;
 }
 
 .edit-button {
-    margin: 0 0 0 60%;
     border-radius: 10%;
     border: none;
-    background-color: #f4f5f7;
-    width: 5%;
-    height: 4%;
-    cursor: pointer;
+    background-color: #007bff;
+    width: 50px;
+    height: 40px;
+    margin-right: 10px;
 }
 
-.edit-button:hover {
-    background-color: #ffffff;
+
+.delete-button {
+    border-radius: 10%;
+    border: none;
+    background-color: #dc3545;
+    width: 50px;
+    height: 40px;
+
 }
+
+.action-button:hover {
+    background-color: #f4f5f7;
+}
+
 
 p {
     font-weight: bold;
 }
 
 h3 {
-    margin: 1% 0 0 15%;
+    margin-left: 15%;
 }
 
 .content {

--- a/src/public/css/top.css
+++ b/src/public/css/top.css
@@ -29,6 +29,7 @@ body{
     background-color: #ffffff;
     cursor: pointer;
 }
+
 .flex-column{
     display: flex;
     flex-direction: column;

--- a/src/public/css/top.css
+++ b/src/public/css/top.css
@@ -6,7 +6,7 @@ body{
 
 .left-side-bar{
     width: 10%;
-    height: 100vh;
+    height: 200vh;
     background-color: #cdddbd;
 }
 

--- a/src/resources/views/knowledge/post.blade.php
+++ b/src/resources/views/knowledge/post.blade.php
@@ -14,7 +14,7 @@
         <input type="text" class="title" name="title">
         <label for="posts">Content</label>
         <textarea name="content"></textarea>
-        <input type="file" name="images[]" multiple/>
+        <input type="file" name="image"/>
         <button type="submit" class="send-button">送信</button>
     </form>
 

--- a/src/resources/views/layout/master.blade.php
+++ b/src/resources/views/layout/master.blade.php
@@ -9,12 +9,11 @@
         <link rel="stylesheet" href="{{ asset('/css/top.css') }}">
 </head>
 <body>
-    <aside class="left-side-bar">
+    <div class="left-side-bar">
         <form method="GET" action="{{ route('Knowledge.index') }}" >
             <button class="home-button">Home</button>
         </form>
-        <button class="trush-button">g</button>
-    </aside>
+    </div>
     <div class="flex-column">
         <header>
             <div class="user-name">

--- a/src/resources/views/post/detail.blade.php
+++ b/src/resources/views/post/detail.blade.php
@@ -2,24 +2,38 @@
 @section('title', 'top画面')
 
 <link rel="stylesheet" href="{{ asset('/css/post-detail.css') }}">
+<!-- CSS only -->
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
+<!-- JavaScript Bundle with Popper -->
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
+
 
 @section('content')
 @auth
 @foreach ($posts as $post)
-    <h1>{{ $post->title }}</h1>
+    <h1 class="mt-2">{{ $post->title }}</h1>
 @if (session('flashMessage'))
     <div class="flash_message">
         {{ session('flashMessage') }}
     </div>
 @endif
-
+<div class="post-container">
     <div class="post-details">
-        <p>{{ $post->users->name }}</p>
-        <p>{{ $post->updated_at->format('Y-m-d') }}</p>
+            <p>{{ $post->users->name }}</p>
+            <p>{{ $post->updated_at->format('Y-m-d') }}</p>
     </div>
-    <form action="{{ route('Knowledge.edit', ['id' => $post->id ])}}" method="get">
-        <button class="edit-button">編集</button>
-    </form>
+    <div class="post-actions">
+        <form action="{{ route('Knowledge.edit', ['id' => $post->id ])}}" method="get">
+            @csrf
+            <button class="action-button edit-button">編集</button>
+        </form>
+        <!-- Button trigger modal -->
+        <button type="button" class="action-button delete-button" data-bs-toggle="modal" data-bs-target="#deleteModal">
+        削除
+        </button>
+    </div>
+</div>
+
     <h3>Content</h3>
     <div class="content">
         {{ $post->content }}
@@ -30,6 +44,27 @@
             <p>[参考画像]</p>
             <img src="{{ Storage::url($postImage->img_path) }}" />
         </div>
+
+    <!-- Modal -->
+    <div class="modal fade" id="deleteModal" tabindex="-1" aria-labelledby="exampleModalLabel" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+            <div class="modal-header d-block text-center">
+                <h1 class="modal-title fs-5 text" id="exampleModalLabel">削除確認</h1>
+            </div>
+            <div class="modal-body text-center">
+                本当に削除しても大丈夫ですか？
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">キャンセル</button>
+                <form action="{{ route('Knowledge.delete', ['id' => $post->id ])}}" method="post">
+                    @csrf
+                    @method('delete')
+                <button class="btn btn-danger">削除</button>
+                </form>
+            </div>
+        </div>
+    </div>
     @endforeach
 @endforeach
 @endauth

--- a/src/resources/views/post/detail.blade.php
+++ b/src/resources/views/post/detail.blade.php
@@ -11,7 +11,7 @@
 @section('content')
 @auth
 @foreach ($posts as $post)
-    <h1 class="mt-2">{{ $post->title }}</h1>
+    <h1>{{ $post->title }}</h1>
 @if (session('flashMessage'))
     <div class="flash_message">
         {{ session('flashMessage') }}

--- a/src/resources/views/post/detail.blade.php
+++ b/src/resources/views/post/detail.blade.php
@@ -27,7 +27,6 @@
             @csrf
             <button class="action-button edit-button">編集</button>
         </form>
-        <!-- Button trigger modal -->
         <button type="button" class="action-button delete-button" data-bs-toggle="modal" data-bs-target="#deleteModal">
         削除
         </button>
@@ -44,17 +43,17 @@
             <p>[参考画像]</p>
             <img src="{{ Storage::url($postImage->img_path) }}" />
         </div>
-
-    <!-- Modal -->
+    @endforeach
     <div class="modal fade" id="deleteModal" tabindex="-1" aria-labelledby="exampleModalLabel" aria-hidden="true">
-        <div class="modal-dialog">
-            <div class="modal-content">
+    <div class="modal-dialog">
+        <div class="modal-content">
             <div class="modal-header d-block text-center">
                 <h1 class="modal-title fs-5 text" id="exampleModalLabel">削除確認</h1>
             </div>
             <div class="modal-body text-center">
                 本当に削除しても大丈夫ですか？
             </div>
+
             <div class="modal-footer">
                 <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">キャンセル</button>
                 <form action="{{ route('Knowledge.delete', ['id' => $post->id ])}}" method="post">
@@ -65,7 +64,8 @@
             </div>
         </div>
     </div>
-    @endforeach
+</div>
+
 @endforeach
 @endauth
 @endsection

--- a/src/resources/views/post/edit.blade.php
+++ b/src/resources/views/post/edit.blade.php
@@ -17,7 +17,7 @@
             <input type="text" class="title" name="title" value={{ $post->title }}>
             <label for="posts">Content</label>
             <textarea name="content">{{ $post->content }}</textarea>
-            <input type="file" name="images[]" multiple/>
+            <input type="file" name="image"/>
             <button type="submit" class="send-button">送信</button>
         </form>
     @endforeach

--- a/src/resources/views/top/index.blade.php
+++ b/src/resources/views/top/index.blade.php
@@ -5,12 +5,12 @@
 
 @section('content')
 @auth
+<h1>投稿一覧</h1>
 @if (session('flash_message'))
     <div class="flash_message">
         {{ session('flash_message') }}
     </div>
 @endif
-<h1>投稿一覧</h1>
 @foreach($posts as $post)
     <a href="{{ route('Knowledge.detail', ['id' => $post->id]) }}">
         <div class="card">

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -35,6 +35,8 @@ Route::group(['prefix' => 'Knowledge', 'as' => 'Knowledge.', 'middleware' => 'au
     Route::get('{id}/edit', [App\Http\Controllers\KnowledgeController::class, 'showEdit'])->name('edit');
     //投稿詳細画面に遷移
     Route::get('{id}', [App\Http\Controllers\KnowledgeController::class, 'KnowledgeDetail'])->name('detail');
+    // 投稿削除処理
+    Route::delete('{id}', [App\Http\Controllers\KnowledgeController::class, 'deletePost'])->name('delete');
     //投稿編集処理をし、投稿詳細画面に遷移
     Route::put('{id}', [App\Http\Controllers\KnowledgeController::class, 'updatePost'])->name('update');
 });


### PR DESCRIPTION
# 課題のリンク
・投稿削除機能

# 改修内容
・投稿詳細画面に、削除ボタンを作成
・削除ボタンを押下後、
１、モーダルが発火。
２、削除ボタンを押下すると、$postIdと一致した画像と投稿を削除する。
・削除処理完了後、投稿詳細画面に遷移し、flashMessageを表示。


# 検証内容
・dd()を使い、投稿内容（title, content)がController、PostModelに渡っていることを確認
・Postテーブルにて、投稿内容がdeleteされていることを確認。
・削除処理完了後、投稿詳細画面に遷移し、flashメッセージが表示されていることを確認。